### PR TITLE
update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
 torch==1.0.1
-tensorflow==1.15
+tensorflow==1.14
 numpy
 typing
 tensorboardX
 matplotlib
-phonemize
+phonemizer
 librosa
-multiprocessing


### PR DESCRIPTION
`multiprocessing` is pre-installed in `>python2.6`, and `phonemizer` was misspelled, and `tensorflow==15.0` was bugging for whatever reason (it should be removed soon anyways)